### PR TITLE
🔒 Add input length restrictions to contact form

### DIFF
--- a/contact.diff
+++ b/contact.diff
@@ -1,0 +1,52 @@
+<<<<<<< SEARCH
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  placeholder="Jane Appleseed"
+                  required
+                />
+=======
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  placeholder="Jane Appleseed"
+                  required
+                  maxlength="100"
+                />
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  placeholder="email@example.com"
+                  required
+                />
+=======
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  placeholder="email@example.com"
+                  required
+                  maxlength="100"
+                />
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+                <textarea
+                  id="message"
+                  name="message"
+                  placeholder="How can I help?"
+                  required
+                ></textarea>
+=======
+                <textarea
+                  id="message"
+                  name="message"
+                  placeholder="How can I help?"
+                  required
+                  maxlength="1000"
+                ></textarea>
+>>>>>>> REPLACE

--- a/contact.html
+++ b/contact.html
@@ -203,6 +203,7 @@
                   name="name"
                   placeholder="Jane Appleseed"
                   required
+                  maxlength="100"
                 />
                 <span class="error-message">This field is required</span>
               </div>
@@ -214,6 +215,7 @@
                   name="email"
                   placeholder="email@example.com"
                   required
+                  maxlength="100"
                 />
                 <span class="error-message">This field is required</span>
               </div>
@@ -224,6 +226,7 @@
                   name="message"
                   placeholder="How can I help?"
                   required
+                  maxlength="1000"
                 ></textarea>
                 <span class="error-message">This field is required</span>
               </div>


### PR DESCRIPTION
🎯 **What:** Added missing input length restrictions to the contact form fields.
⚠️ **Risk:** Missing 'maxlength' is a common input validation hygiene issue. It could allow a user to input an extremely large amount of data, potentially causing issues if the data is processed or stored by a backend service.
🛡️ **Solution:** Added 'maxlength="100"' to the 'name' and 'email' inputs, and 'maxlength="1000"' to the 'message' textarea in 'contact.html'. Verified the fix using Playwright and visually inspected the results.

---
*PR created automatically by Jules for task [5791798702270400109](https://jules.google.com/task/5791798702270400109) started by @LangheBogdan*