### PR TITLE
Fix CSP 'frame-ancestors' ignored via meta tag

### DIFF
--- a/bookmark.html
+++ b/bookmark.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->

--- a/contact.html
+++ b/contact.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->
@@ -147,8 +143,8 @@
                 I’m eager to hear about your projects and explore how I can
                 contribute. As I search for my next role, I’m open to diverse
                 opportunities, with a special interest in joining a
-                Bucharest-based team. I bring energy, dedication, and a keen
-                eye for detail to every challenge I take on.
+                Bucharest-based team. I bring energy, dedication, and a keen eye
+                for detail to every challenge I take on.
               </p>
               <div class="social-links-contact">
                 <a href="#" aria-label="GitHub">

--- a/fylo.html
+++ b/fylo.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->

--- a/index.html
+++ b/index.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->

--- a/insure.html
+++ b/insure.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->

--- a/manage.html
+++ b/manage.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->

--- a/portfolio.html
+++ b/portfolio.html
@@ -18,10 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="frame-ancestors 'self';"
-    />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO Meta Tags -->

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,9 @@
 services:
   - type: static
     name: extraordinary-website
-    buildCommand: npm run build
-    publishPath: dist
+    buildCommand: ""
+    publishPath: ./
+    headers:
+      - path: /*
+        name: Content-Security-Policy
+        value: "default-src 'none'; script-src 'self' https://www.googletagmanager.com 'sha256-lpQko9erkyE7U43qlObViqhvNhGozGo0VLrNaW+N+Js='; style-src 'self' https://fonts.googleapis.com; img-src 'self' https://cdn.simpleicons.org https://www.googletagmanager.com; font-src https://fonts.gstatic.com; connect-src https://www.google-analytics.com; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"


### PR DESCRIPTION
This PR resolves the browser warning "The Content Security Policy directive 'frame-ancestors' is ignored when delivered via a <meta> element." by moving the CSP configuration from HTML <meta> tags to Render HTTP headers. 

Key changes:
1. Removed the `<meta http-equiv="Content-Security-Policy" ... />` tag from `index.html`, `portfolio.html`, `contact.html`, `manage.html`, `bookmark.html`, `insure.html`, and `fylo.html`.
2. Updated `render.yaml` to include a global CSP header for all paths (`/*`).
3. Correctly hashed the inline Google Analytics script (`sha256-lpQko9erkyE7U43qlObViqhvNhGozGo0VLrNaW+N+Js=`) to maintain security without using 'unsafe-inline'.
4. Included all external domains required by the site (Google Tag Manager, Google Fonts, Simple Icons, Google Analytics).
5. Synced `render.yaml` with the live service settings (empty build command and root publish directory).

---
*PR created automatically by Jules for task [10233155611767876966](https://jules.google.com/task/10233155611767876966) started by @LangheBogdan*